### PR TITLE
Fixed `ViewDefinition.sync_many` breaking when the design doc already exists.

### DIFF
--- a/couchbase_mapping/design.py
+++ b/couchbase_mapping/design.py
@@ -142,10 +142,6 @@ class ViewDefinition(object):
         given list of `ViewDefinition` instances match the code defined in
         those instances.
 
-        This function might update more than one design document. This is done
-        using the CouchDB bulk update feature to ensure atomicity of the
-        operation.
-
         :param db: the `Bucket` instance
         :param views: a sequence of `ViewDefinition` instances
         :param remove_missing: whether views found in a design document that
@@ -162,7 +158,7 @@ class ViewDefinition(object):
         for design, views in groupby(views, key=attrgetter('design')):
             doc_id = '_design/%s' % design
             try:
-                doc = db[doc_id]
+                doc = db[doc_id].ddoc
             except Exception:
                 doc = {}
             orig_doc = deepcopy(doc)

--- a/couchbase_mapping/tests/design.py
+++ b/couchbase_mapping/tests/design.py
@@ -26,6 +26,24 @@ class DesignTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
         design_doc = db['_design/foo'].ddoc
         self.assertTrue(design_doc['views']['foo']['options'] == options)
 
+    def test_multiple_views(self):
+        map_by_name = 'function(doc, meta) {emit(doc.name, null)}'
+        view1 = design.ViewDefinition(
+            'test_multiple_views',
+            'by_name',
+            map_by_name)
+        map_by_id = 'function(doc, meta) {emit(meta.id, null)}'
+        view2 = design.ViewDefinition(
+            'test_multiple_views',
+            'by_id',
+            map_by_id)
+        _, db = self.temp_db()
+        view1.sync(db)
+        view2.sync(db)
+        design_doc = db['_design/test_multiple_views'].ddoc
+        self.assertEqual(design_doc['views']['by_name']['map'], map_by_name)
+        self.assertEqual(design_doc['views']['by_id']['map'], map_by_id)
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
`deepcopy(doc)` crashed because it's not ok to `deepcopy` Couchbase `DesignDoc` objects (they have a reference to the bucket). Using the `ddoc` property that is a dict now instead.
Added also a test case for this issue.
